### PR TITLE
`/users/{ランダム文字列} ` にルーティング変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def show
-    @user = User.find(params[:id])
+    @user = User.find_by(url_digest: params[:url_digest])
     @nweets = @user.nweets.paginate(page: params[:page], per_page: 50)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  before_create :set_url_digest
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -23,4 +25,9 @@ class User < ApplicationRecord
       str.gsub(/\W/, '_')[0...20]
     end
   end
+
+  private
+    def set_url_digest
+      self.url_digest = SecureRandom.urlsafe_base64
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,10 @@ class User < ApplicationRecord
     Nweet.all # currently it is global! (since FF is not implemented)
   end
 
+  def to_param
+    url_digest
+  end
+
   class << self
     def screen_name_formatter(str)
       str.gsub(/\W/, '_')[0...20]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,6 @@ class User < ApplicationRecord
 
   private
     def set_url_digest
-      self.url_digest = SecureRandom.urlsafe_base64
+      self.url_digest = SecureRandom.alphanumeric
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   get 'pages/home'
   get 'pages/about'
 
-  resources :users, except: [:index]
+  resources :users, except: [:index], param: :url_digest
   resources :nweets, only: [:create, :update, :destroy]
 end

--- a/db/migrate/20190522140204_add_url_disgest_to_users.rb
+++ b/db/migrate/20190522140204_add_url_disgest_to_users.rb
@@ -1,0 +1,6 @@
+class AddUrlDisgestToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :url_digest, :string
+    add_index :users, :url_digest, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_04_173055) do
+ActiveRecord::Schema.define(version: 2019_05_22_140204) do
 
   create_table "nweets", force: :cascade do |t|
     t.datetime "did_at"
@@ -45,9 +45,11 @@ ActiveRecord::Schema.define(version: 2019_05_04_173055) do
     t.string "handle_name", limit: 30
     t.string "screen_name", limit: 20
     t.string "icon"
+    t.string "url_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["screen_name"], name: "index_users_on_screen_name", unique: true
+    t.index ["url_digest"], name: "index_users_on_url_digest", unique: true
   end
 
 end

--- a/lib/tasks/url_digest.rake
+++ b/lib/tasks/url_digest.rake
@@ -4,7 +4,7 @@ namespace :url_digest do
   task :set_url_digest => :environment do
     User.all.each do |user|
       if user.url_digest.nil?
-        user.url_digest = SecureRandom.urlsafe_base64
+        user.url_digest = SecureRandom.alphanumeric
         user.save
       end
     end

--- a/lib/tasks/url_digest.rake
+++ b/lib/tasks/url_digest.rake
@@ -1,0 +1,12 @@
+namespace :url_digest do
+  desc "Set random url-digest to existing users"
+
+  task :set_url_digest => :environment do
+    User.all.each do |user|
+      if user.url_digest.nil?
+        user.url_digest = SecureRandom.urlsafe_base64
+        user.save
+      end
+    end
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -7,6 +7,9 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show' do
+    assert_not_equal user_path(@user), "/users/#{@user.id}"
+    assert_equal user_path(@user), "/users/#{@user.url_digest}"
+
     get user_path(@user)
     assert_response :success
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,13 +2,16 @@ chikuwa:
   handle_name: "ちくわ大明神"
   screen_name: "chikuwa"
   email: "testing@example.com"
+  url_digest: "E87P1n4T7umwj6zm"
 
 emiya:
   handle_name: "えみや"
   screen_name: "emiya_shiro"
   email: "shiro@emiya.com"
+  url_digest: "idQ0cqViHdxUxTRF"
 
 shinji:
   handle_name: "S. Mato"
   screen_name: "mato_shinji"
   email: "shinji@matou.com"
+  url_digest: "bJUPf2DQrGHlxqVB"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -28,4 +28,10 @@ class UserTest < ActiveSupport::TestCase
     @user.handle_name = " "
     assert @user.valid?
   end
+
+  test 'url_digest must be generated' do
+    new_user = User.new(screen_name: "kaburanai", email: "kaburan@gmail.com", password: "hogehoge")
+    new_user.save
+    assert_not_empty new_user.url_digest
+  end
 end


### PR DESCRIPTION
#21 を解消

既存ユーザーにはurl_digestが設定されていないので、
```rake url_digest:set_url_digest```　とかやる必要ありそう

アイコンとかのパス変えるの大変そうなので、内部的にはまだ連番のIDが動いています……。