### PR TITLE
Fix twitter bugs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,11 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def tweet(content = render_tweet(current_user.autotweet_content))
-    current_user.tweet(content)
+    begin
+      current_user.tweet(content)
+    rescue
+      flash[:warning] = 'ツイートに失敗しました。Twitterアカウントの状態を確認してください。'
+    end
   end
 
   protected

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,8 @@ class User < ApplicationRecord
       twitter_uid: nil,
       twitter_screen_name: nil,
       twitter_access_token: nil,
-      twitter_access_secret: nil
+      twitter_access_secret: nil,
+      autotweet_enabled: false
     )
   end
 

--- a/lib/tasks/twitter_task.rake
+++ b/lib/tasks/twitter_task.rake
@@ -1,0 +1,6 @@
+namespace :twitter_task do
+  desc "Disable autotweet when no account is registered"
+  task :disable_autotweet_with_no_account => :environment do
+    User.where(twitter_uid: nil).update_all(autotweet_enabled: false)
+  end
+end

--- a/test/controllers/twitters_controller_test.rb
+++ b/test/controllers/twitters_controller_test.rb
@@ -1,7 +1,4 @@
 require 'test_helper'
 
 class TwittersControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -34,4 +34,11 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_nil @user.twitter_url
     assert_nil @user.twitter_screen_name
   end
+
+  test 'autotweet is disabled when delete twitter account' do
+    @user.autotweet_enabled = true
+    @user.delete_twitter_account
+
+    assert_not @user.autotweet_enabled
+  end
 end

--- a/test/integration/autotweet_test.rb
+++ b/test/integration/autotweet_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class AutotweetTest < ActionDispatch::IntegrationTest
+  def setup
+    Nuita::Application.load_tasks
+    @user = users(:girl) # no twitter
+  end
+
+  test 'task(disable_autotweet_with_no_account) test' do
+    @user.update_attribute(:autotweet_enabled, true)
+
+    Rake::Task['twitter_task:disable_autotweet_with_no_account'].invoke
+    assert_empty User.where(autotweet_enabled: true)
+  end
+end


### PR DESCRIPTION
fix #53

<img width="964" alt="スクリーンショット 2019-07-23 16 28 16" src="https://user-images.githubusercontent.com/19870474/61693128-f7ad1e80-ad69-11e9-8004-f0a885520518.png">

あとこれも治した
<img width="420" alt="スクリーンショット 2019-07-23 16 51 11" src="https://user-images.githubusercontent.com/19870474/61693217-1dd2be80-ad6a-11e9-8fc1-c5f2cfd7bd64.png">

`twitter_task:disable_autotweet_with_no_account` で既存DBもいい感じに治せる