### PR TITLE
close #59

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -79,10 +79,10 @@ class Link < ApplicationRecord
       when /nijie/
         str = page.css('//script[@type="application/ld+json"]/text()').first.to_s
 
-        if s = str.match(/https:\/\/pic.nijie.(net|info)\/(\d+)\/[^\/]+\/nijie_picture\/([^"]+)/)
+        if s = str.match(/https:\/\/pic.nijie.(net|info)\/(?<servername>\d+)\/[^\/]+\/nijie_picture\/(?<imagename>[^"]+)/)
           # 動画は容量大きすぎるし取らない
-          if s[2] =~ (/(jpg|png)/)
-            'https://pic.nijie.net/' + s[1] + '/nijie_picture/' + s[2]
+          if s[:imagename] =~ (/(jpg|png)/)
+            'https://pic.nijie.net/' + s[:servername] + '/nijie_picture/' + s[:imagename]
           else
             str
           end

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -46,6 +46,13 @@ class LinkTest < ActiveSupport::TestCase
     @link = Link.create(url: url)
 
     assert_match '__rs_l160x160', @link.image
+
+    # cf: issue #59
+    url = 'https://nijie.info/view.php?id=322323'
+    url = Link.normalize_url(url)
+    @link = Link.create(url: url)
+
+    assert_equal 'https://pic.nijie.net/05/nijie_picture/3965_20190710041444_0.png', @link.image
   end
 
   test 'fetch pixiv correctly' do


### PR DESCRIPTION
正規表現の `(jpg|png)` 的なのもキャプチャされちゃうの知らなかった・・・

名前付きのキャプチャ使うようにしたから当該箇所はもう大丈夫だと思う