### PR TITLE
フォローボタンをタイムライン上のヌイートに表示

### DIFF
--- a/app/assets/javascripts/nweets.js
+++ b/app/assets/javascripts/nweets.js
@@ -6,7 +6,6 @@ document.addEventListener('turbolinks:load', function(){
       var a = div.firstElementChild;
       var i = a.childNodes[0];
       var num = a.childNodes[1];
-      var flash = div.childNodes[1];
       a.classList.toggle('faved');
 
       var n;
@@ -19,8 +18,6 @@ document.addEventListener('turbolinks:load', function(){
       if(i.classList.contains('fas')){
         i.classList.replace('fas', 'far');
         a.setAttribute('data-method', 'post');
-        flash.classList.remove('faved-flash')
-        flash.innerText = '';
         n--;
         if(n){
           num.innerText = n;
@@ -30,8 +27,6 @@ document.addEventListener('turbolinks:load', function(){
       }else{
         i.classList.replace('far', 'fas');
         a.setAttribute('data-method', 'delete');
-        //flash.innerText = 'いいねしました！';
-        flash.classList.add('faved-flash');
         n++;
         num.innerText = n;
       }

--- a/app/assets/javascripts/nweets.js
+++ b/app/assets/javascripts/nweets.js
@@ -32,4 +32,28 @@ document.addEventListener('turbolinks:load', function(){
       }
     })
   });
+
+  document.querySelectorAll('.follow-icon-link').forEach(function(a){
+    a.addEventListener('ajax:success', function(){
+      var span = a.firstElementChild;
+      var i = span.firstElementChild;
+
+      if(span.classList.contains('unfollowable')){
+        a.setAttribute('data-method', 'post');
+        if(i.classList.contains('fa-exchange-alt')){
+          i.classList.replace('fa-exchange-alt', 'fa-user-plus');
+        }else{
+          i.classList.replace('fa-user-check', 'fa-user-plus');
+        }
+      }else{
+        a.setAttribute('data-method', 'delete');
+        if(span.classList.contains('follower-true')){
+          i.classList.replace('fa-user-plus', 'fa-exchange-alt');
+        }else{
+          i.classList.replace('fa-user-plus', 'fa-user-check');
+        }
+      }
+      span.classList.toggle('unfollowable');
+    });
+  });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -22,13 +22,13 @@ document.addEventListener('turbolinks:load', function(){
 
   if(!!btn){
     btn.addEventListener('click', () => {
-      btn.value = 'フォローする';
+      btn.innerText = 'フォローする';
     }, false);
     btn.addEventListener('mouseover', () => {
-      btn.value = 'フォロー解除';
+      btn.innerText = 'フォロー解除';
     }, false);
     btn.addEventListener('mouseout', () => {
-      btn.value = 'フォロー中';
+      btn.innerText = 'フォロー中';
     }, false);
   }
 });

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -468,13 +468,12 @@ body{
       padding-left: 0.5rem;
       font-size: small;
       color: #aaa;
+      &:hover{
+        color: $brand-color-hover;
+      }
     }
 
-    .followable:hover{
-      color: $brand-color-hover;
-    }
-
-    .unfollowable:hover{
+    .follow-icon.unfollowable:hover{
       color: $fav-color-light;
     }
   }

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -463,6 +463,20 @@ body{
         color: #bbb;
       }
     }
+
+    .follow-icon{
+      padding-left: 0.5rem;
+      font-size: small;
+      color: #aaa;
+    }
+
+    .followable:hover{
+      color: $brand-color-hover;
+    }
+
+    .unfollowable:hover{
+      color: $fav-color-light;
+    }
   }
 }
 

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -4,12 +4,20 @@ class RelationshipsController < ApplicationController
   def create
     user = User.find_by(url_digest: params[:followee])
     current_user.follow(user)
-    head :no_content
+    if request.xhr?
+      head :no_content
+    else
+      redirect_back(fallback_location: root_path)
+    end
   end
 
   def destroy
     user = User.find_by(url_digest: params[:followee])
     current_user.unfollow(user)
-    head :no_content
+    if request.xhr?
+      head :no_content
+    else
+      redirect_back(fallback_location: root_path)
+    end
   end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -4,12 +4,12 @@ class RelationshipsController < ApplicationController
   def create
     user = User.find_by(url_digest: params[:followee])
     current_user.follow(user)
-    redirect_back(fallback_location: root_url)
+    head :no_content
   end
 
   def destroy
     user = User.find_by(url_digest: params[:followee])
     current_user.unfollow(user)
-    redirect_back(fallback_location: root_url)
+    head :no_content
   end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -2,14 +2,14 @@ class RelationshipsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    user = User.find(params[:followee_id])
+    user = User.find_by(url_digest: params[:followee])
     current_user.follow(user)
-    redirect_to user
+    redirect_back(fallback_location: root_url)
   end
 
   def destroy
-    user = Relationship.find(params[:id]).followee
+    user = User.find_by(url_digest: params[:followee])
     current_user.unfollow(user)
-    redirect_to user
+    redirect_back(fallback_location: root_url)
   end
 end

--- a/app/views/nweets/_follow_icon.html.slim
+++ b/app/views/nweets/_follow_icon.html.slim
@@ -1,11 +1,13 @@
 / 普通にヘルパー使えば良い気がするけど、
   条件分岐こうやって書いたほうがクエリ呼び出し2回で済んで早い気がする
 - if current_user.followee?(user)
-  span.follow-icon.unfollowable
-    - if current_user.follower?(user)
-      = icon 'fas', 'exchange-alt'
-    - else
-      = icon 'fas', 'user-check'
+  = link_to relationship_path(followee: user), method: :delete, remote: true,class: 'follow-icon-link' do
+    span.follow-icon.unfollowable class="follower-#{current_user.follower?(user).to_s}"
+      - if current_user.follower?(user)
+        = icon 'fas', 'exchange-alt'
+      - else
+        = icon 'fas', 'user-check'
 - else
-  span.follow-icon.followable
-    = icon 'fas', 'user-plus'
+  = link_to relationship_path(followee: user), method: :post, remote: true,class: 'follow-icon-link' do
+    span.follow-icon class="follower-#{current_user.follower?(user).to_s}"
+      = icon 'fas', 'user-plus'

--- a/app/views/nweets/_follow_icon.html.slim
+++ b/app/views/nweets/_follow_icon.html.slim
@@ -1,0 +1,11 @@
+/ 普通にヘルパー使えば良い気がするけど、
+  条件分岐こうやって書いたほうがクエリ呼び出し2回で済んで早い気がする
+- if current_user.followee?(user)
+  span.follow-icon.unfollowable
+    - if current_user.follower?(user)
+      = icon 'fas', 'exchange-alt'
+    - else
+      = icon 'fas', 'user-check'
+- else
+  span.follow-icon.followable
+    = icon 'fas', 'user-plus'

--- a/app/views/nweets/_nweet.html.slim
+++ b/app/views/nweets/_nweet.html.slim
@@ -8,6 +8,8 @@ li.nweet
         | @
         = link_to nweet.user.screen_name, nweet.user
       span.timestamp = nweet.did_at.in_time_zone('Tokyo')
+      - if @timeline && other_user?(nweet.user)
+        = render 'nweets/follow_icon', user: nweet.user
     .content
       .maincontent
         span.time = time_ago_in_japanese(nweet.did_at)
@@ -16,7 +18,6 @@ li.nweet
         = render 'nweets/card', nweet: nweet
       - if nweet.statement? && (!@timeline || followee_or_self?(nweet.user))
         .quote = text_url_to_link(nweet.statement).html_safe
-
       .nweet-bottom
         .float-left
           - if user_signed_in?

--- a/app/views/users/_follow.html.slim
+++ b/app/views/users/_follow.html.slim
@@ -1,4 +1,1 @@
-.user-follow-form
-  = form_for(current_user.active_relationships.build) do |f|
-    = hidden_field_tag :followee_id, user.id
-    = f.submit "フォローする", class: "btn btn-follow btn-outline-primary"
+= link_to 'フォローする', relationship_path(followee: user), method: :post, class: 'btn btn-follow', id: 'buttonFollow'

--- a/app/views/users/_unfollow.html.slim
+++ b/app/views/users/_unfollow.html.slim
@@ -1,2 +1,1 @@
-= form_for(current_user.active_relationships.find_by(followee_id: user.id),html: { method: :delete }) do |f|
-  = f.submit "フォロー中", class: "btn btn-unfollow", id: "buttonUnfollow"
+= link_to 'フォロー中', relationship_path(followee: user), method: :delete, class: 'btn btn-unfollow', id: 'buttonUnfollow'

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -7,6 +7,8 @@ li.nweet
       span.screen_name
         | @
         = link_to user.screen_name, user
+      - if other_user?(user)
+        = render 'nweets/follow_icon', user: user
     .content
       .maincontent
         .user-status-in-list

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
   resources :nweets, only: [:create, :update, :destroy, :show], param: :url_digest
   resource :favorite, only: [:create, :destroy]
   resource :link, only: [:create]
-  resources :relationships, only: [:create, :destroy]
+  resource :relationship, only: [:create, :destroy]
 end

--- a/test/controllers/relationships_controller_test.rb
+++ b/test/controllers/relationships_controller_test.rb
@@ -1,17 +1,4 @@
 require 'test_helper'
 
 class RelationshipsControllerTest < ActionDispatch::IntegrationTest
-  test 'create should require logged in user' do
-    assert_no_difference 'Relationship.count' do
-      post relationships_path
-    end
-    assert_redirected_to new_user_session_url
-  end
-
-  test "destroy should require logged-in user" do
-    assert_no_difference 'Relationship.count' do
-      delete relationship_path(relationships(:one))
-    end
-    assert_redirected_to new_user_session_url
-  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -76,7 +76,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_no_match @shinji.biography, response.body
 
     login_as @user
-    post relationships_path, params: {followee_id: @shinji.id}
+    post relationship_path(followee: @shinji)
     get user_path(@shinji)
     assert_match @shinji.biography, response.body
   end

--- a/test/integration/followee_test.rb
+++ b/test/integration/followee_test.rb
@@ -16,7 +16,7 @@ class FolloweeTest < ActionDispatch::IntegrationTest
     get root_path
     assert_no_match @nweet.statement, response.body
 
-    post relationships_path, params: {followee_id: @other_user.id}
+    post relationship_path(followee: @other_user)
     get root_path
     assert_match @nweet.statement, response.body
   end


### PR DESCRIPTION
- Relationshipsコントローラーを単数形リソースに変更 (id使わずにユーザーで指定したほうがajaxやりやすい……)
- タイムライン上のヌイートにフォロー／リムーブボタン追加 (闇ajax)
- ↑のボタンの形でFFは分かるけど、「一方的にフォローされている」を示すアイコンがないので中途半端
- いいやつないかな (できたらFont Awesomeで)