### PR TITLE
Contribution graph

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -2,14 +2,20 @@ document.addEventListener('turbolinks:load', function(){
   var pathname = location.pathname;
   var element;
 
-  if (~pathname.indexOf('likes')){
-    element = document.getElementById('badgeLikes');
-  }else if(~pathname.indexOf('followers')){
-    element = document.getElementById('badgeFollowers');
-  }else if(~pathname.indexOf('followees')){
-    element = document.getElementById('badgeFollowees');
-  }else if(~pathname.indexOf('users')){
-    element = document.getElementById('badgeNweets');
+  if(~(m = location.search.match(/\d{4}%2F\d{2}%2F\d{2}/))){
+    element = document.getElementById('cal' + unescape(m));
+  }else{
+    if (~pathname.indexOf('likes')){
+      element = document.getElementById('badgeLikes');
+    }else if(~pathname.indexOf('followers')){
+      element = document.getElementById('badgeFollowers');
+    }else if(~pathname.indexOf('followees')){
+      element = document.getElementById('badgeFollowees');
+    }else if(~pathname.indexOf('users')){
+      element = document.getElementById('badgeNweets');
+    }else{
+      element = null
+    }
   }
 
   if(!!element){

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -2,7 +2,7 @@ document.addEventListener('turbolinks:load', function(){
   var pathname = location.pathname;
   var element;
 
-  if(~(m = location.search.match(/\d{4}%2F\d{2}%2F\d{2}/))){
+  if(m = location.search.match(/\d{4}%2F\d{2}%2F\d{2}/)){
     element = document.getElementById('cal' + unescape(m));
   }else{
     if (~pathname.indexOf('likes')){

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -511,6 +511,10 @@ body{
       font-size: small;
     }
   }
+
+  .label-calendar{
+    font-size: small;
+  }
 }
 
 .registration_button{
@@ -619,6 +623,12 @@ a.card{
     padding: 0;
     border: 2px solid #fcfcfc;
     background-color: $contribution-color-more;
+
+    a{
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
   }
   td.val-1{
     background-color: $contribution-color-one;
@@ -626,6 +636,10 @@ a.card{
   td.val-0{
     background-color: $contribution-color-zero;
   }
+}
+
+h3.label-calendar{
+  font-size: normal;
 }
 
 /* footer */

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -615,12 +615,14 @@ a.card{
 .table-contribution{
   font-size: x-small;
   margin: 0 auto;
+  border-collapse: separate;
+  border-spacing: 1px;
 
   td{
     width: 1.5rem;
     height: 1.5rem;
     margin: 0px;
-    padding: 0;
+    padding: 0px;
     border: 2px solid #fcfcfc;
     background-color: $contribution-color-more;
 
@@ -635,6 +637,13 @@ a.card{
   }
   td.val-0{
     background-color: $contribution-color-zero;
+  }
+  td.active{
+    border: 4px;
+  }
+
+  tr{
+    margin: 0;
   }
 }
 

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -16,6 +16,10 @@ $twitter-color: #00acee;
 $fav-color: #c73b31;
 $fav-color-light: #aa544e;
 
+$contribution-color-zero: rgb(235, 237, 240);
+$contribution-color-one: rgb(123, 201, 111);
+$contribution-color-more: rgb(25, 97, 39);
+
 .navbar{
   background-color: $brand-color;
   box-shadow: 0px 4px 10px rgba(0,0,0,0.1);
@@ -601,6 +605,27 @@ textarea{
 a.card{
   text-decoration: none;
   color: inherit;
+}
+
+/* contribution graph */
+.table-contribution{
+  font-size: x-small;
+  margin: 0 auto;
+
+  td{
+    width: 1.5rem;
+    height: 1.5rem;
+    margin: 0px;
+    padding: 0;
+    border: 2px solid #fcfcfc;
+    background-color: $contribution-color-more;
+  }
+  td.val-1{
+    background-color: $contribution-color-one;
+  }
+  td.val-0{
+    background-color: $contribution-color-zero;
+  }
 }
 
 /* footer */

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,11 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find_by(url_digest: params[:url_digest])
-    @nweets = @user.nweets.paginate(page: params[:page], per_page: 50)
+    if params[:date]
+      @nweets = @user.nweets_at_date(params[:date].to_time).paginate(page: params[:page])
+    else
+      @nweets = @user.nweets.paginate(page: params[:page], per_page: 50)
+    end
   end
 
   def likes

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,6 +26,16 @@ module ApplicationHelper
     end
   end
 
-
+  # contribution graph用
+  # collectionを渡すとcolumnの日ごとに整理されたhashになって返ってくる
+  def calendarize_data(collection, column: :created_at)
+    Hash.new([]).tap do |hash|
+      collection.each do |c|
+        date = c.send(column).to_date
+        hash[date] = [] if hash[date].empty?
+        hash[date] << c
+      end
+    end
+  end
 
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -34,4 +34,15 @@ module UsersHelper
   def followee_or_self?(user)
     current_user == user || current_user.followee?(user)
   end
+
+  # 1つめの返り値は日にちごとのヌイートが入ったハッシュ、2つめは開始日
+  def contribution_for(user, row)
+    # カレンダーの内訳: (row - 1)行分の完全な週 + 日曜〜今日まで
+    start_day = Date.current.beginning_of_week(:sunday) - (row - 1).week
+    nweets = user.nweets.where(:created_at=> start_day..Time.current)
+
+    hash = calendarize_data(nweets, column: :did_at)
+
+    return hash, start_day
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,10 @@ class User < ApplicationRecord
     Nweet.all # currently it is global! (since FF is not implemented)
   end
 
+  def nweets_at_date(date)
+    nweets.where(did_at: date.beginning_of_day...date.end_of_day)
+  end
+
   def to_param
     url_digest
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord
   end
 
   def nweets_at_date(date)
-    nweets.where(did_at: date.beginning_of_day...date.end_of_day)
+    nweets.where(did_at: date.beginning_of_day...date.end_of_day).reorder(did_at: :asc)
   end
 
   def to_param

--- a/app/views/nweets/_nweet.html.slim
+++ b/app/views/nweets/_nweet.html.slim
@@ -1,4 +1,4 @@
-li.nweet
+li.nweet id="nweet#{nweet.url_digest}"
   .icon
     = link_to icon_for(nweet.user, size: 50), nweet.user
   .right

--- a/app/views/users/_calendar.html.slim
+++ b/app/views/users/_calendar.html.slim
@@ -1,0 +1,8 @@
+h6.mt-3.calendar カレンダー
+
+table.table.table-contribution
+  - (hash, start_day = contribution_for(user, 5))
+  - (start_day..Date.current).each do |date|
+    - if date.sunday?
+      tr
+    td = hash[date].count

--- a/app/views/users/_calendar.html.slim
+++ b/app/views/users/_calendar.html.slim
@@ -1,8 +1,8 @@
-h6.mt-3.calendar カレンダー
+h3.small.mt-3.mb-2.calendar カレンダー
 
-table.table.table-contribution
+table.table-contribution
   - (hash, start_day = contribution_for(user, 5))
   - (start_day..Date.current).each do |date|
     - if date.sunday?
       tr
-    td = hash[date].count
+    td class = "val-#{hash[date].count}"

--- a/app/views/users/_calendar.html.slim
+++ b/app/views/users/_calendar.html.slim
@@ -8,6 +8,6 @@ table.table-contribution
   - (start_day..Date.current).each do |date|
     - if date.sunday?
       tr
-    td class="val-#{hash[date].count}"
+    td class="val-#{hash[date].count}" id="cal#{date}"
       - if hash[date].any?
         = link_to '', user_path(user, date: date)

--- a/app/views/users/_calendar.html.slim
+++ b/app/views/users/_calendar.html.slim
@@ -1,8 +1,13 @@
-h3.small.mt-3.mb-2.calendar カレンダー
+- (hash, start_day = contribution_for(user, 6))
+
+.mt-3.mb-2.label-calendar
+  | グラフ
+  span.small.pl-1 = "#{start_day} - #{Date.current}"
 
 table.table-contribution
-  - (hash, start_day = contribution_for(user, 5))
   - (start_day..Date.current).each do |date|
     - if date.sunday?
       tr
-    td class = "val-#{hash[date].count}"
+    td class="val-#{hash[date].count}"
+      - if hash[date].any?
+        = link_to '', user_path(user, date: date)

--- a/app/views/users/_user_info.html.slim
+++ b/app/views/users/_user_info.html.slim
@@ -34,3 +34,5 @@ section.user-info
     - if !@detail && friend?(user) && user.twitter_url?
       = link_to user.twitter_url do
         = icon('fab', 'twitter', '@' + user.twitter_screen_name)
+  - if friend?(user)
+    = render 'users/calendar', user: user, row: 5

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -80,4 +80,10 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get user_path(@shinji)
     assert_match @shinji.biography, response.body
   end
+
+  test 'show nweets by date' do
+    # nweets(:christmas) 参照
+    get user_path(@user, date: "2017-12-25".to_time)
+    assert_match '😢', response.body
+  end
 end

--- a/test/fixtures/nweets.yml
+++ b/test/fixtures/nweets.yml
@@ -24,3 +24,9 @@ saytwo:
   user: emiya
   statement: '？？？？？？？？？？？？？'
   url_digest: <%= SecureRandom.alphanumeric %>
+
+chirstmas:
+  did_at: '2017-12-25 01:00 +09:00'
+  user: chikuwa
+  url_digest: <%= SecureRandom.alphanumeric %>
+  statement: '😢'


### PR DESCRIPTION
<img width="233" alt="スクリーンショット 2019-08-20 20 41 59" src="https://user-images.githubusercontent.com/19870474/63344342-2f1fe280-c38b-11e9-9c49-6431682c0c0d.png">

射精をGitHubのContribution Graph風に表示することができるようになりました。  
当初思い描いていた機能はほぼこれで完遂できたので胸がいっぱいです。
スマホ対応はガバガバなので今後縦横回転させたりできるようにしたい

<img width="980" alt="スクリーンショット 2019-08-20 20 42 15" src="https://user-images.githubusercontent.com/19870474/63344343-2f1fe280-c38b-11e9-8f77-8da93b4be5b3.png">

日にちをクリックするとその日のヌイート一覧が見られます。
相互なら他のユーザーのグラフも見に行けます。