### PR TITLE
フォロー・フォロワーをフレンドに公開／自己紹介を全体公開の「ひとこと」へ

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -168,6 +168,12 @@ body{
   background-color: rgba(255,255,255,0.9)
 }
 
+.form-group{
+  i{
+    font-size: small;
+  }
+}
+
 .wider-margintop{
   margin-top: 30px;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,5 @@
 class UsersController < ApplicationController
-  before_action :friend_user, only: [:likes]
-  before_action :correct_user, only: [:followers, :followees]
+  before_action :authenticate_user!, :friend_user, only: [:likes, :followers, :followees]
 
   def show
     @user = User.find_by(url_digest: params[:url_digest])
@@ -35,7 +34,7 @@ class UsersController < ApplicationController
     def friend_user
       @user = User.find_by(url_digest: params[:url_digest])
       unless @user == current_user || (@user.followee?(current_user) && @user.follower?(current_user))
-        redirect_to(new_user_session_url)
+        redirect_to(user_path(@user))
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
   validates :screen_name, presence: true, uniqueness: true, length: {maximum: 20}
   validates :screen_name, format: {with: /[0-9a-zA-Z_]/}
   validates :handle_name, length: {maximum: 30}
+  validates :biography, length: {maximum: 30}
 
   has_many :active_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy
   has_many :followees, through: :active_relationships

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -33,8 +33,10 @@
       .form-group.row
         .col-md-3
           = f.label :biography, class: "col-form-label"
+          i
+            | (30文字以内)
         .col-md-9
-          = f.text_area :biography, maxlength: 100, rows: 2, class: "form-control"
+          = f.text_area :biography, maxlength: 30, rows: 1, class: "form-control"
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?
         div
           | Currently waiting confirmation for:

--- a/app/views/users/_user_info.html.slim
+++ b/app/views/users/_user_info.html.slim
@@ -34,5 +34,4 @@ section.user-info
     - if !@detail && friend?(user) && user.twitter_url?
       = link_to user.twitter_url do
         = icon('fab', 'twitter', '@' + user.twitter_screen_name)
-  - if friend?(user)
-    = render 'users/calendar', user: user, row: 5
+  = render 'users/calendar', user: user, row: 5

--- a/app/views/users/_user_info.html.slim
+++ b/app/views/users/_user_info.html.slim
@@ -23,7 +23,6 @@ section.user-info
       = link_to(likes_user_path(user), class: "list-group-item d-flex justify-content-between align-items-center") do
         | いいね
         span.badge.badge-brand.badge-pill#badgeLikes = user.fav_nweets.count
-    - if current_user?(user)
       = link_to(followees_user_path(user), class: "list-group-item d-flex justify-content-between align-items-center") do
         | フォロー
         span.badge.badge-brand.badge-pill#badgeFollowees = user.followees.count

--- a/app/views/users/_user_info.html.slim
+++ b/app/views/users/_user_info.html.slim
@@ -12,7 +12,7 @@ section.user-info
     - if current_user.follower?(user)
       .my-1#you-are-followed
         span.label-muted フォローされています
-  - if !@timeline && user.biography && friend?(user)
+  - if user.biography
       .my-2
         = text_url_to_link(user.biography).html_safe
   .list-group

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,7 +18,7 @@ ja:
         email: "メールアドレス"
         password_confirmation: "パスワード(確認)"
         icon: "アイコン"
-        biography: "自己紹介"
+        biography: "ひとこと"
   date:
     abbr_day_names:
     - 日

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -45,29 +45,31 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_not @user.autotweet_enabled
   end
 
-  test 'should redirect followees view to other user' do
+  test 'should redirect followees view to not-friend' do
     get followees_user_path(@user)
     assert_redirected_to new_user_session_url
 
     login_as(@user)
     # shinjiはフォロワー0人. フォローはしてる
     get followees_user_path(@shinji)
-    assert_redirected_to new_user_session_url
+    assert_redirected_to user_path(@shinji)
 
-    get followees_user_path(@user)
+    post relationship_path(followee: @shinji)
+    get followees_user_path(@shinji)
     assert_response :success
   end
 
-  test 'should redirect followers view to other user' do
+  test 'should redirect followers view to not-friend' do
     get followers_user_path(@user)
     assert_redirected_to new_user_session_url
 
     login_as(@user)
     # shinjiはフォロワー0人. フォローはしてる
     get followers_user_path(@shinji)
-    assert_redirected_to new_user_session_url
+    assert_redirected_to user_path(@shinji)
 
-    get followers_user_path(@user)
+    post relationship_path(followee: @shinji)
+    get followers_user_path(@shinji)
     assert_response :success
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -73,7 +73,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   test 'should show or hide biography' do
     get user_path(@shinji)
-    assert_no_match @shinji.biography, response.body
+    assert_match @shinji.biography, response.body
 
     login_as @user
     post relationship_path(followee: @shinji)


### PR DESCRIPTION
いづれもユーザーの個人ページで見える情報の変更です。

- フォロー・フォロワーをフレンドに公開するようになりました。
- 自己紹介は上限30文字の「ひとこと」に変更され、全体へ公開されるようになります。
- グラフも全体へ公開されます。

他のユーザーに見せる情報について迷っていましたが、

- ヌイート(の分析)やオカズなど、**射精に直接関連する** 情報 -> **全体公開**
- フォロー／フォロワーやいいね、名前やtwitter垢など、 **射精には関係のない** 情報 -> 基本 **フレンドのみ公開** 、オプションで完全非公開

という感じでやっていけたらなあと思っています　